### PR TITLE
Merge fix/issue-10

### DIFF
--- a/docker/config/create_config.go
+++ b/docker/config/create_config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"log"
-	"strconv"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -81,12 +80,13 @@ func (b *Builder) MemoryLimit(memoryLimit int) *Builder {
 	return b
 }
 
-// DiskSpace sets maximum disk space allocated for the container (in megabytes)
-func (b *Builder) DiskSpace(diskSpace int) *Builder {
-	b.Config.HostConfig.StorageOpt = make(map[string]string)
-	b.Config.HostConfig.StorageOpt["size"] = strconv.Itoa(diskSpace) + "MB"
-	return b
-}
+// FIXME: https://github.com/synalice/gobox/issues/10
+//// DiskSpace sets maximum disk space allocated for the container (in megabytes)
+//func (b *Builder) DiskSpace(diskSpace int) *Builder {
+//	b.Config.HostConfig.StorageOpt = make(map[string]string)
+//	b.Config.HostConfig.StorageOpt["size"] = strconv.Itoa(diskSpace) + "MB"
+//	return b
+//}
 
 // CPUCount sets max amount of CPU cycles for the container.
 // Be aware that it might collide with TimeLimit since 1 CPU cycle is approximately 1 second.

--- a/docker/config/create_config_test.go
+++ b/docker/config/create_config_test.go
@@ -40,8 +40,7 @@ func TestConfigBuilder(t *testing.T) {
 		Mount(mount3).
 		TimeLimit(3 * time.Second).
 		MemoryLimit(64).
-		CPUCount(6).
-		DiskSpace(64)
+		CPUCount(6)
 	containerConfig := configBuilder.Build()
 
 	log.Println(containerConfig)

--- a/docker/container/container_creation_test.go
+++ b/docker/container/container_creation_test.go
@@ -44,8 +44,7 @@ func TestOnLoad(t *testing.T) {
 				Mount(mount1).
 				TimeLimit(1 * time.Second).
 				MemoryLimit(64).
-				CPUCount(1000).
-				DiskSpace(1024)
+				CPUCount(1000)
 			newConfig := configBuilder.Build()
 
 			containerBuilder := container.NewContainerBuilder(ctrl)

--- a/docker/container/container_lifecycle_test.go
+++ b/docker/container/container_lifecycle_test.go
@@ -48,8 +48,7 @@ func TestContainerLifecycle(t *testing.T) {
 		Mount(mount3).
 		TimeLimit(1 * time.Second).
 		MemoryLimit(64).
-		CPUCount(1000).
-		DiskSpace(1024)
+		CPUCount(1000)
 	newConfig := configBuilder.Build()
 
 	containerBuilder := container.NewContainerBuilder(ctrl)

--- a/examples/container_creation.go
+++ b/examples/container_creation.go
@@ -47,8 +47,7 @@ func main() {
 		Mount(mount3).
 		TimeLimit(1 * time.Second).
 		MemoryLimit(64).
-		CPUCount(1000).
-		DiskSpace(1024)
+		CPUCount(1000)
 	newConfig := configBuilder.Build()
 
 	containerBuilder := container.NewContainerBuilder(ctrl)


### PR DESCRIPTION
Temporary solution for [issue #10](#10). It prevents `config.NewConfigBuilder().DiskSpace()` from being used until the [issue #10](#10) is fully fixed.