### PR TITLE
Merge fix/issue-8-fix

### DIFF
--- a/docker/config/create_config.go
+++ b/docker/config/create_config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"log"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -40,10 +39,11 @@ func NewConfigBuilder(controller *controller.Controller) *Builder {
 
 // Image sets image that container will use
 func (b *Builder) Image(image string) *Builder {
-	err := EnsureImage(b.controller, image)
-	if err != nil {
-		log.Println("couldn't pull an image from the dockerhub:", err)
-	}
+	// FIXME: https://github.com/synalice/gobox/issues/8#issuecomment-1152683742
+	//err := EnsureImage(b.controller, image)
+	//if err != nil {
+	//	log.Println("couldn't pull an image from the dockerhub:", err)
+	//}
 
 	b.Config.ContainerConfig.Image = image
 	return b

--- a/examples/container_creation.go
+++ b/examples/container_creation.go
@@ -52,6 +52,14 @@ func main() {
 	configBuilder := config.NewConfigBuilder(ctrl)
 	configBuilder.
 		// An image that the container will use.
+		//
+		// IMPORTANT! Make sure that an image you are trying to use
+		// actually exists on your machine. It will not be pulled
+		// from the registry automatically because this process heavily
+		// affects the performance.
+		//
+		// Read more about why this happens:
+		// https://github.com/synalice/gobox/issues/8#issuecomment-1152683742
 		Image("python").
 
 		// A command that will be executed when container starts.


### PR DESCRIPTION
A very brute and hopefully temporary solution for [issue 8](https://github.com/synalice/gobox/issues/8). Performance is now much better, but an image won't be pulled from the registry automatically if it does not exist on the host's machine.